### PR TITLE
Adding Y4000 Sonde

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "YosemitechModbus",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "keywords": "Yosemitech, Modbus, communication, bus, sensor",
   "description": "Arduino library for communication with Yosemitech sensors via Modbus.",
   "repository":
@@ -14,6 +14,10 @@
       "name": "Sara Damiano",
       "email": "sdamiano@stroudcenter.org",
       "maintainer": true
+    },
+    {
+      "name": "Anthony Aufdenkampe",
+      "email": "aaufdenkampe@limno.com"
     }
   ],
   "license": "BSD-3-Clause",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=YosemitechModbus
-version=0.1.11
+version=0.1.12
 author=Sara Damiano <sdamiano@stroudcenter.org>
 maintainer=Sara Damiano <sdamiano@stroudcenter.org>
 sentence=Arduino library for communication with Yosemitech sensors via Modbus.

--- a/sensor_tests/Y4000/Y4000.ino
+++ b/sensor_tests/Y4000/Y4000.ino
@@ -1,0 +1,131 @@
+/*****************************************************************************
+Modified by Anthony Aufdenkampe, from GetValues.ino
+2018-April
+Y4000 MultiParameter Sonde
+
+Depends on EnvrioDIY_SensorModbusMaster, but not YosemitechModbus
+*****************************************************************************/
+
+// ---------------------------------------------------------------------------
+// Include the base required libraries
+// ---------------------------------------------------------------------------
+#include <Arduino.h>
+#include <AltSoftSerial.h>
+#include "YosemitechModbus.h"
+
+
+// ---------------------------------------------------------------------------
+// Set up the sensor specific information
+//   ie, pin locations, addresses, calibrations and related settings
+// ---------------------------------------------------------------------------
+
+// Define the sensor type
+yosemitechModel model = Y4000;  // The sensor model number
+
+// Define the sensor's modbus address
+byte modbusAddress = 0x01;  // The sensor's modbus address, or SlaveID
+// Yosemitech ships sensors with a default ID of 0x01.
+
+// Define pin number variables
+const int PwrPin = 22;  // The pin sending power to the sensor *AND* RS485 adapter
+const int DEREPin = -1;   // The pin controlling Recieve Enable and Driver Enable
+                          // on the RS485 adapter, if applicable (else, -1)
+                          // Setting HIGH enables the driver (arduino) to send text
+                          // Setting LOW enables the receiver (sensor) to send text
+
+// Construct software serial object for Modbus
+AltSoftSerial modbusSerial;  // On Mayfly, requires connection D5 & D6
+
+// Construct the modbus instance
+modbusMaster modbus;
+
+
+
+// ---------------------------------------------------------------------------
+// Working Functions
+// ---------------------------------------------------------------------------
+
+// Give values to variables;
+yosemitechModel _model = model;
+byte modbusSlaveID = modbusAddress;
+byte _slaveID = modbusSlaveID;
+
+String getSerialNumber(void)
+{
+    String SN;
+    switch (_model)
+    {
+        case Y4000:
+            SN = modbus.StringFromRegister(0x03, 0x1400, 14); break; // for Y4000 Sonde
+        default:
+            SN = modbus.StringFromRegister(0x03, 0x0900, 14); break; // for all sensors except Y4000
+    }
+
+    // Strip out the initial ')' that seems to come with some responses
+    if (SN.startsWith(")"))
+    {
+        SN = SN.substring(1);
+    }
+
+    // Return the serial number
+    return SN;
+}
+
+bool startMeasurement(void)
+{
+    switch (_model)
+    {
+        case Y520:
+        {
+            byte startMeasurementW[9] = {_slaveID, 0x10, 0x1C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+                                      // _slaveID, Write, Reg 7168 ,0 Registers, 0byte,    CRC
+            int respSize = modbus.sendCommand(startMeasurementW, 9);
+            if (respSize == 8 && modbus.responseBuffer[0] == _slaveID) return true;
+            else return false;
+            break;
+        }
+        default:
+        {
+            byte startMeasurementR[8] = {_slaveID, 0x03, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00};
+                                      // _slaveID, Read,  Reg 9472 ,   0 Regs  ,    CRC
+            int respSize = modbus.sendCommand(startMeasurementR, 8);
+            if (respSize == 5 && modbus.responseBuffer[0] == _slaveID) return true;
+            else return false;
+            break;
+        }
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Main setup function
+// ---------------------------------------------------------------------------
+void setup()
+{
+
+    pinMode(PwrPin, OUTPUT);
+    digitalWrite(PwrPin, HIGH);
+
+    if (DEREPin > 0) pinMode(DEREPin, OUTPUT);
+
+    Serial.begin(57600);  // Main serial port for debugging via USB Serial Monitor
+    modbusSerial.begin(9600);  // The modbus serial stream - Baud rate MUST be 9600.
+
+    // Start up the modbus sensor
+    modbus.begin(modbusAddress, &modbusSerial, DEREPin);
+
+    Serial.println(getSerialNumber());
+
+    Serial.println(startMeasurement());
+
+    Serial.println('done!');
+}
+
+
+// ---------------------------------------------------------------------------
+// Main loop function
+// ---------------------------------------------------------------------------
+void loop()
+{
+
+}

--- a/src/YosemitechModbus.cpp
+++ b/src/YosemitechModbus.cpp
@@ -401,7 +401,7 @@ bool yosemitech::getValues(float &parmValue, float &secondValue, float &thirdVal
     // If something fails, we'll get here
     return false;
 }
-bool yosemitech::getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue);
+bool yosemitech::getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue)
 {
     byte errorCode = 0xFF;  // Initialize as if there's an error
     return getValues(parmValue, tempValue, thirdValue, errorCode);

--- a/src/YosemitechModbus.cpp
+++ b/src/YosemitechModbus.cpp
@@ -250,7 +250,7 @@ bool yosemitech::stopMeasurement(void)
 // beginning in holding register 0x1200 (4608).  As a convienence, I am also
 // calculating the DO in mg/L from the DO sensor, which otherwise would only
 // return percent saturation.
-bool yosemitech::getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue,  byte &errorCode);
+bool yosemitech::getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue,  byte &errorCode)
 {
     // Set values to -9999 and error flagged before asking for the result
     parmValue = -9999;
@@ -687,7 +687,7 @@ uint16_t yosemitech::getBrushInterval(void)
     {
         case Y4000:   // Y4000 Multiparameter sonde
         {
-            rreturn modbus.int16FromRegister(0x0E00, 0x3200, littleEndian);
+            return modbus.int16FromRegister(0x0E00, 0x3200, littleEndian);
         }
         default:
         {

--- a/src/YosemitechModbus.h
+++ b/src/YosemitechModbus.h
@@ -100,7 +100,7 @@ public:
     bool getValues(float &parmValue, float &tempValue, float &thirdValue);
     bool getValues(float &parmValue, float &tempValue, float &thirdValue, byte &errorCode);
     bool getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue); // For Y4000 Sonde
-
+    bool getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue,  byte &errorCode);
     // This gets the main "parameter" value as a float
     // This is overloaded, so you have the option of getting the error code
     // in another pre-initialized variable, if you want it and the sensor
@@ -119,8 +119,6 @@ public:
     // This only applies to DO and is calculated in the getValues() equation using
     // the measured temperature and a salinity of 0 and pressure of 760 mmHg (sea level)
     float getDOmgLValue(void);
-
-    // ** NEED a list of getValue functions for the Y4000
 
     // This gets the calibration constants for the sensor
     // The float variables must be initialized prior to calling this function.

--- a/src/YosemitechModbus.h
+++ b/src/YosemitechModbus.h
@@ -101,7 +101,7 @@ public:
     bool getValues(float &parmValue, float &tempValue, float &thirdValue, byte &errorCode);
     // 8 values - For Y4000 Sonde, in this order: "DO; Turb; Cond; pH; Temp; ORP; Chl; BGA"
     // 8 values and an error code - As 8 values, but with error code
-    // NOTE:  The 8 value versiosn will return false for anything but a sonde
+    // NOTE:  The 8 value versions will return false for anything but a sonde
     bool getValues(float &firstValue, float &secondValue, float &thirdValue, float &forthValue, float &fifthValue, float &sixthValue, float &seventhValue, float &eighthValue); // For Y4000 Sonde
     bool getValues(float &firstValue, float &secondValue, float &thirdValue, float &forthValue, float &fifthValue, float &sixthValue, float &seventhValue, float &eighthValue,  byte &errorCode);
     // This gets the main "parameter" value as a float

--- a/src/YosemitechModbus.h
+++ b/src/YosemitechModbus.h
@@ -23,7 +23,7 @@ typedef enum yosemitechModel
     Y533,  // ORP?
     Y550,  // UV254 Sensor http://www.yosemitech.com/en/product-21.html
     Y4000, //  Multiparameter Sonde http://www.yosemitech.com/en/product-20.html
-    UNKNOWN   //  Use if the sensor model is unknown. Doing this is generally a
+    UNKNOWN   // Use if the sensor model is unknown. Doing this is generally a
               // bad idea, but it can be helpful for doing things like getting
               // the serial number of an unknown model.
 } yosemitechModel;
@@ -91,16 +91,19 @@ public:
     //            sensors that return can return something else
     //            -- Y532 (pH) can return electrical potential
     //            -- Y504 (DO) allows calculation of DO in mg/L, which can be returned
-    // 3 values and an error code - As two values, but with error code
-    // 8 values - For Y4000 Sonde, in this order: "DO; Turb; Cond; pH; Temp; ORP; Chl; BGA"
+    // 3 values and an error code - As three values, but with error code
+    // NOTE:  The one, two, and three value variants will simply return false for a sonde
     bool getValues(float &parmValue);
     bool getValues(float &parmValue, byte &errorCode);
     bool getValues(float &parmValue, float &tempValue);
     bool getValues(float &parmValue, float &tempValue, byte &errorCode);
     bool getValues(float &parmValue, float &tempValue, float &thirdValue);
     bool getValues(float &parmValue, float &tempValue, float &thirdValue, byte &errorCode);
-    bool getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue); // For Y4000 Sonde
-    bool getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue,  byte &errorCode);
+    // 8 values - For Y4000 Sonde, in this order: "DO; Turb; Cond; pH; Temp; ORP; Chl; BGA"
+    // 8 values and an error code - As 8 values, but with error code
+    // NOTE:  The 8 value versiosn will return false for anything but a sonde
+    bool getValues(float &firstValue, float &secondValue, float &thirdValue, float &forthValue, float &fifthValue, float &sixthValue, float &seventhValue, float &eighthValue); // For Y4000 Sonde
+    bool getValues(float &firstValue, float &secondValue, float &thirdValue, float &forthValue, float &fifthValue, float &sixthValue, float &seventhValue, float &eighthValue,  byte &errorCode);
     // This gets the main "parameter" value as a float
     // This is overloaded, so you have the option of getting the error code
     // in another pre-initialized variable, if you want it and the sensor

--- a/src/YosemitechModbus.h
+++ b/src/YosemitechModbus.h
@@ -99,7 +99,7 @@ public:
     bool getValues(float &parmValue, float &tempValue, byte &errorCode);
     bool getValues(float &parmValue, float &tempValue, float &thirdValue);
     bool getValues(float &parmValue, float &tempValue, float &thirdValue, byte &errorCode);
-    bool getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue,  byte &errorCode); // For Y4000 Sonde
+    bool getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue); // For Y4000 Sonde
 
     // This gets the main "parameter" value as a float
     // This is overloaded, so you have the option of getting the error code

--- a/src/YosemitechModbus.h
+++ b/src/YosemitechModbus.h
@@ -21,7 +21,8 @@ typedef enum yosemitechModel
     Y520,  // 4-Electrode Conductivity Sensor http://www.yosemitech.com/en/product-3.html
     Y532,  // pH
     Y533,  // ORP?
-    Y550,   // UV254 Sensor http://www.yosemitech.com/en/product-21.html
+    Y550,  // UV254 Sensor http://www.yosemitech.com/en/product-21.html
+    Y4000, //  Multiparameter Sonde http://www.yosemitech.com/en/product-20.html
     UNKNOWN   //  Use if the sensor model is unknown. Doing this is generally a
               // bad idea, but it can be helpful for doing things like getting
               // the serial number of an unknown model.
@@ -91,12 +92,14 @@ public:
     //            -- Y532 (pH) can return electrical potential
     //            -- Y504 (DO) allows calculation of DO in mg/L, which can be returned
     // 3 values and an error code - As two values, but with error code
+    // 8 values - For Y4000 Sonde, in this order: "DO; Turb; Cond; pH; Temp; ORP; Chl; BGA"
     bool getValues(float &parmValue);
     bool getValues(float &parmValue, byte &errorCode);
     bool getValues(float &parmValue, float &tempValue);
     bool getValues(float &parmValue, float &tempValue, byte &errorCode);
     bool getValues(float &parmValue, float &tempValue, float &thirdValue);
     bool getValues(float &parmValue, float &tempValue, float &thirdValue, byte &errorCode);
+    bool getValues(float &parmValue, float &secondValue, float &thirdValue, float &forthValue, float &tempValue, float &sixthValue, float &seventhValue, float &eighthValue,  byte &errorCode); // For Y4000 Sonde
 
     // This gets the main "parameter" value as a float
     // This is overloaded, so you have the option of getting the error code
@@ -116,6 +119,8 @@ public:
     // This only applies to DO and is calculated in the getValues() equation using
     // the measured temperature and a salinity of 0 and pressure of 760 mmHg (sea level)
     float getDOmgLValue(void);
+
+    // ** NEED a list of getValue functions for the Y4000
 
     // This gets the calibration constants for the sensor
     // The float variables must be initialized prior to calling this function.

--- a/utilities/GetSlaveID/GetSlaveID.ino
+++ b/utilities/GetSlaveID/GetSlaveID.ino
@@ -162,7 +162,8 @@ void scanSNs(void)
     int numFound = 0;
     for (uint8_t addrTest = 1; addrTest <= 247; addrTest++)
     {
-        byte getSN[] = {addrTest, 0x03, 0x09, 0x00, 0x00, 0x07, 0x00, 0x00};
+        byte getSN[] = {addrTest, 0x03, 0x09, 0x00, 0x00, 0x07, 0x00, 0x00}; // for all except Y4000 Sonde
+//        byte getSN[] = {addrTest, 0x03, 0x14, 0x00, 0x00, 0x07, 0x00, 0x00}; // for Y4000 Sonde
         insertCRC(getSN, sizeof(getSN)/sizeof(getSN[0]));
 
         // Send the "get serial number" command


### PR DESCRIPTION
I have carefully gone through the Y4000 modbus manual to get all request and response frames for the sonde, and added them to the .h & .cpp files. I have confirmed that these are the correct codes using the windows software from YosemiTech. Finally, several of the functions worked independently when added to .ino file.

@SRGDamia1, could you help get this to compile. The issue seems to be with my additions to the already overloaded getValues command, which for the Y4000 fetches 8 variables at once.