### PR TITLE
Restore Y550 for backward compatibility; Bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yosemitech Modbus
 
-A library to use an Arduino as a master to control and communicate with the sensors produced by [Yosemitech](http://www.yosemitech.com/en/) via [Modbus RTU](https://en.wikipedia.org/wiki/Modbus) over [RS-485](https://en.wikipedia.org/wiki/RS-485).  This library requires the use of the [EnviroDIY/SensorModbusMaster](https://github.com/EnviroDIY/SensorModbusMaster) library.
+A library to use an Arduino as a master to control and communicate with the sensors produced by [Yosemitech](http://en.yosemitech.com) via [Modbus RTU](https://en.wikipedia.org/wiki/Modbus) over [RS-485](https://en.wikipedia.org/wiki/RS-485).  This library requires the use of the [EnviroDIY/SensorModbusMaster](https://github.com/EnviroDIY/SensorModbusMaster) library.
 
 YosemiTech sensors only support these modbus commands:
 * 3 (0x03, Read holding registers)
@@ -23,8 +23,8 @@ All of these sensors require a 5-12V DC power supply and the power supply can be
 The current consumption of the Yosemitech sensors is specified to be <50mA, this is not accurate for their sensors which include a wiper brush, for these sensors an inductive spike exists when the brush begins to spin, which draws significantly more current than specified. Below is a table describing the current draws for several different opeating conditions of the Yosemitech 511 Turbidity senor (with brush). All tests were driven by a power supply with a 9v output
 
 | Condition        | Current    |   
-| ------------- |:-------------:| 
-| Brush Starting | <290mA<sup>1</sup>| 
+| ------------- |:-------------:|
+| Brush Starting | <290mA<sup>1</sup>|
 | Brush Running     | 52mA      |
 | Sensing | 27mA     |
 | Idle | 7mA |

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "YosemitechModbus",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "keywords": "Yosemitech, Modbus, communication, bus, sensor",
   "description": "Arduino library for communication with Yosemitech sensors via Modbus.",
   "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=YosemitechModbus
-version=0.3.0
+version=0.3.1
 author=Sara Damiano <sdamiano@stroudcenter.org>
 maintainer=Sara Damiano <sdamiano@stroudcenter.org>
 sentence=Arduino library for communication with Yosemitech sensors via Modbus.

--- a/src/YosemitechModbus.cpp
+++ b/src/YosemitechModbus.cpp
@@ -44,6 +44,7 @@ String yosemitech::getModel(void)
         case Y520: {return "Y520";}
         case Y532: {return "Y532";}
         case Y533: {return "Y533";}
+        case Y550: {return "Y550";}
         case Y551: {return "Y551";}
         case Y560: {return "Y560";}
         case Y4000: {return "Y4000";}
@@ -67,6 +68,7 @@ String yosemitech::getParameter(void)
         case Y520: {return "Conductivity";}
         case Y532: {return "pH";}
         case Y533: {return "ORP";}
+        case Y550: {return "COD";}
         case Y551: {return "COD";}
         case Y560: {return "Ammonium";}
         case Y4000: {return "DO,   Turb, Cond,  pH,   Temp, ORP,  Chl,  BGA";}
@@ -90,6 +92,7 @@ String yosemitech::getUnits(void)
         case Y520: {return "mS/cm";}
         case Y532: {return "pH, mV";}
         case Y533: {return "mV";}
+        case Y550: {return "mg/L, NTU";}
         case Y551: {return "mg/L, NTU";}
         case Y560: {return "mg/L";}
         case Y4000: {return "mg/L, NTU,  mS/cm, pH,   °C,   mV,   µg/L, µg/L";}
@@ -316,6 +319,7 @@ bool yosemitech::getValues(float &parmValue, float &tempValue, float &thirdValue
             }
             break;
         }
+        case Y550:   // Y550 COD, old vesion (not tested)
         case Y551:   // Y551 COD, with turbidity
         {
             if (modbus.getRegisters(0x03, 0x2600, 5))

--- a/src/YosemitechModbus.h
+++ b/src/YosemitechModbus.h
@@ -37,6 +37,8 @@ typedef enum yosemitechModel
       // http://en.yosemitech.com/aspcms/product/2020-6-15/154.html
     Y533,  // ORP
       // http://en.yosemitech.com/aspcms/product/2020-5-8/91.html
+    Y550,  // UV254/COD Sensor, old version no longer sold
+      // http://en.yosemitech.com/aspcms/product/2020-5-8/94.html
     Y551,  // UV254/COD Sensor
       // http://en.yosemitech.com/aspcms/product/2020-5-8/94.html
     Y560,  // NH4 Probe
@@ -111,7 +113,7 @@ public:
     //            sensors that return can return something else
     //            -- Y532 (pH) can return electrical potential
     //            -- Y551 (COD) can return turbidity
-    //            -- Y550 (Ammonium) returns NH4_N (mg/L) and pH as primary parameters, but can return more.
+    //            -- Y560 (Ammonium) returns NH4_N (mg/L) and pH as primary parameters, but can return more.
     //            -- Y504 (DO) allows calculation of DO in mg/L, which can be returned
     // 3 values and an error code - As three values, but with error code
     // NOTE:  The one, two, and three value variants will simply return false for a sonde


### PR DESCRIPTION
To address #21 and https://github.com/EnviroDIY/YosemitechModbus/commit/416fa28d425bfc625cd870844f22ab893da217bd#commitcomment-65821601

For version 0.30.1, bug fix release