### PR TITLE
Add Y513 Blue Green Algae (BGA) and fix examples

### DIFF
--- a/examples/GetValues/GetValues.ino
+++ b/examples/GetValues/GetValues.ino
@@ -25,7 +25,7 @@
 //  Sensor Settings
 // ==========================================================================
 // Define the sensor type
-yosemitechModel model = Y521;  // The sensor model number
+yosemitechModel model = Y504;  // The sensor model number
 
 // Define the sensor's modbus address, or SlaveID
 // NOTE: YosemiTech Windows software presents SlaveID as an integer (decimal),
@@ -37,24 +37,25 @@ byte modbusAddress = 0x01;  // Yosemitech ships sensors with default ID 0x01
 int32_t modbusBaud = 9600;  // 9600 is the default baud rate for most sensors
 
 
-// Sensor Timing
-// Edit these to explore
-#define WARM_UP_TIME 1500  // milliseconds for sensor to respond to commands.
+// Time in milliseconds after powering up for the slave device to respond
+#define WARM_UP_TIME 1500 
           // DO responds within 275-300ms;
           // Turbidity and pH within 500ms
           // Conductivity doesn't respond until 1.15-1.2s
 
-#define BRUSH_TIME 10000  // milliseconds for readings to stablize.
+// Time in milliseconds for brush cycle to complete.
+// No readings should be taken during this time.
+#define BRUSH_TIME 10000  
            // On wipered (self-cleaning) models, the brush immediately activates after
            // getting power and takes approximately 10-15 seconds to finish.
            // Turbidity takes 10-11 s
            // Ammonium takes 15 s
-// No readings should be taken during this time.
 
-#define STABILIZATION_TIME 10000  // milliseconds for readings to stablize.
+// Time in milliseconds for readings to stablize.
+#define STABILIZATION_TIME 2000  
 // The modbus manuals recommend the following stabilization times between starting
 // measurements and requesting values (times include brushing time):
-//  2 s for whipered chlorophyll
+//  2 s for chlorophyll with wiper
 // 20 s for turbidity, including 11 s to complete a brush cycle
 // 10 s for conductivity
 //  2 s for COD
@@ -90,14 +91,14 @@ const int32_t serialBaud = 115200;  // Baud rate for serial monitor
 // Define pin number variables
 const int sensorPwrPin  = 10;  // The pin sending power to the sensor
 const int adapterPwrPin = 22;  // The pin sending power to the RS485 adapter
-const int DEREPin       = -1;  // The pin controlling Recieve Enable and Driver Enable
+const int DEREPin       = -1;  // The pin controlling Receive Enable and Driver Enable
                                // on the RS485 adapter, if applicable (else, -1)
                                // Setting HIGH enables the driver (arduino) to send text
                                // Setting LOW enables the receiver (sensor) to send text
 
 // Turn on debugging outputs (i.e. raw Modbus requests & responses)
 // by uncommenting next line (i.e. `#define YM_DEBUG`)
-// #define YM_DEBUG
+// #define DEBUG
 
 
 // ==========================================================================
@@ -147,6 +148,8 @@ HardwareSerial& modbusSerial = Serial;
 
 // Construct the Yosemitech modbus instance
 yosemitech sensor;
+
+// Initialize success flag for set commands
 bool       success;
 
 
@@ -167,17 +170,16 @@ String prettyprintAddressHex(byte _modbusAddress) {
 //  Arduino Setup Function
 // ==========================================================================
 void setup() {
-    // Setup power pins
-    if (sensorPwrPin > 0) {
+    // Set various pins as needed
+    if (DEREPin >= 0) { pinMode(DEREPin, OUTPUT); }
+    if (sensorPwrPin >= 0) {
         pinMode(sensorPwrPin, OUTPUT);
         digitalWrite(sensorPwrPin, HIGH);
     }
-    if (adapterPwrPin > 0) {
+    if (adapterPwrPin >= 0) {
         pinMode(adapterPwrPin, OUTPUT);
         digitalWrite(adapterPwrPin, HIGH);
     }
-
-    if (DEREPin > 0) { pinMode(DEREPin, OUTPUT); }
 
     // Turn on the "main" serial port for debugging via USB Serial Monitor
     Serial.begin(serialBaud);
@@ -215,25 +217,26 @@ void setup() {
     delay(WARM_UP_TIME);
 
     // Confirm Modbus Address
-    Serial.println(F("\nSelected modbus address:"));
-    Serial.print(F("    integer: "));
+    Serial.println(F("\nExpected modbus address:"));
+    Serial.print(F("    Decimal: "));
     Serial.print(modbusAddress, DEC);
-    Serial.print(F(", hexidecimal: "));
+    Serial.print(F(", Hexidecimal: "));
     Serial.println(prettyprintAddressHex(modbusAddress));
 
-    Serial.println(F("Discovered modbus address."));
-    Serial.print(F("    integer: "));
+    // Get the current Modbus Address
+    Serial.println(F("Getting current modbus address..."));
     byte id = sensor.getSlaveID();
+    Serial.print(F("    Decimal: "));
     Serial.print(id, DEC);
-    Serial.print(F(", hexidecimal: "));
+    Serial.print(F(", Hexidecimal: "));
     Serial.println(prettyprintAddressHex(id));
 
-    if (id != modbusAddress) {
+    if (id != 0xFF && id != modbusAddress) {
+        Serial.println(F("\nDiscovered modbus address different than expected!"));
         Serial.print(F("Updating sensor modbus address to: "));
         modbusAddress = id;
         Serial.println(prettyprintAddressHex(modbusAddress));
-        Serial.println();
-        // Restart the sensor
+        // Restart the sensor with the discovered address
         sensor.begin(model, modbusAddress, &modbusSerial, DEREPin);
         delay(1500);
     };

--- a/examples/GetValues/GetValues.ino
+++ b/examples/GetValues/GetValues.ino
@@ -29,19 +29,17 @@
 //  Sensor Settings
 // ==========================================================================
 // Define the sensor type
-yosemitechModel model = Y700;  // The sensor model number
+yosemitechModel model = UNKNOWN;  // The sensor model number
 
 // Define the sensor's modbus address, or SlaveID
 // NOTE: YosemiTech Windows software presents SlaveID as an integer (decimal),
 // whereas EnviroDIY and most other modbus systems present it in hexadecimal form.
 // Use an online "HEX to DEC Converter".
-byte modbusAddress =
-    0x01;  // Yosemitech ships sensors with a default ID of 0x01.
+byte modbusAddress = 0x01;  // Yosemitech ships sensors with default ID 0x01
 
 // Sensor Timing
 // Edit these to explore
-#define WARM_UP_TIME \
-    1000  // milliseconds for sensor to respond to commands.
+#define WARM_UP_TIME 1000  // milliseconds for sensor to respond to commands.
           // DO responds within 275-300ms;
           // Turbidity and pH within 500ms
           // Conductivity doesn't respond until 1.15-1.2s
@@ -90,7 +88,7 @@ byte modbusAddress =
 const int32_t serialBaud = 115200;  // Baud rate for serial monitor
 
 // Define pin number variables
-const int sensorPwrPin  = 11;  // The pin sending power to the sensor
+const int sensorPwrPin  = 10;  // The pin sending power to the sensor
 const int adapterPwrPin = 22;  // The pin sending power to the RS485 adapter
 const int DEREPin       = -1;  // The pin controlling Recieve Enable and Driver Enable
                                // on the RS485 adapter, if applicable (else, -1)

--- a/examples/GetValues/GetValues.ino
+++ b/examples/GetValues/GetValues.ino
@@ -25,7 +25,7 @@
 //  Sensor Settings
 // ==========================================================================
 // Define the sensor type
-yosemitechModel model = Y520;  // The sensor model number
+yosemitechModel model = Y521;  // The sensor model number
 
 // Define the sensor's modbus address, or SlaveID
 // NOTE: YosemiTech Windows software presents SlaveID as an integer (decimal),
@@ -96,8 +96,8 @@ const int DEREPin       = -1;  // The pin controlling Recieve Enable and Driver 
                                // Setting LOW enables the receiver (sensor) to send text
 
 // Turn on debugging outputs (i.e. raw Modbus requests & responses)
-// by uncommenting next line (i.e. `#define DEBUG`)
-// #define DEBUG
+// by uncommenting next line (i.e. `#define YM_DEBUG`)
+// #define YM_DEBUG
 
 
 // ==========================================================================
@@ -198,7 +198,7 @@ void setup() {
     sensor.begin(model, modbusAddress, &modbusSerial, DEREPin);
 
 // Turn on debugging
-#ifdef DEBUG
+#ifdef YM_DEBUG
     sensor.setDebugStream(&Serial);
 #endif
 

--- a/examples/GetValues/platformio.ini
+++ b/examples/GetValues/platformio.ini
@@ -9,7 +9,8 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [platformio]
-description = Changing a setting and reading data from a modbus sensor
+description = Getting a setting and reading data from a modbus sensor
+src_dir = examples/GetValues
 
 [env:mayfly]
 monitor_speed = 115200

--- a/extras/utilities/ChangeSlaveID/ChangeSlaveID.ino
+++ b/extras/utilities/ChangeSlaveID/ChangeSlaveID.ino
@@ -26,12 +26,13 @@ all slaves accept and comply with writing functions broadcast to address 0.)
 yosemitechModel model = UNKNOWN;  // The sensor model number
 
 // Define the sensor's modbus address
-byte oldAddress = 0x01;  // The sensor's original modbus address, or SlaveID
+byte oldAddress = 0x09;  // The sensor's original modbus address, or SlaveID
 // Yosemitech ships sensors with a default ID of 0x01.
-byte newAddress = 0x1A;
+byte newAddress = 0x05;
 
 // Define pin number variables
-const int PwrPin = 22;  // The pin sending power to the sensor *AND* RS485 adapter
+const int sensorPwrPin = 10;  // The pin sending power to the sensor
+const int adapterPwrPin = 22;  // The pin sending power to the RS485 adapter
 const int DEREPin = -1;   // The pin controlling Recieve Enable and Driver Enable
                           // on the RS485 adapter, if applicable (else, -1)
                           // Setting HIGH enables the driver (arduino) to send text
@@ -53,12 +54,16 @@ bool success;
 void setup()
 {
 
-    pinMode(PwrPin, OUTPUT);
-    digitalWrite(PwrPin, HIGH);
+    pinMode(sensorPwrPin, OUTPUT);
+    digitalWrite(sensorPwrPin, HIGH);
+
+    pinMode(adapterPwrPin, OUTPUT);
+    digitalWrite(adapterPwrPin, HIGH);
+
 
     if (DEREPin > 0) pinMode(DEREPin, OUTPUT);
 
-    Serial.begin(57600);  // Main serial port for debugging via USB Serial Monitor
+    Serial.begin(115200);  // Main serial port for debugging via USB Serial Monitor
     modbusSerial.begin(9600);  // The modbus serial stream - Baud rate MUST be 9600.
 
     Serial.println(F("ChangeSlaveID_AltSoftSerial.ino"));

--- a/extras/utilities/GetSlaveID/GetSlaveID.ino
+++ b/extras/utilities/GetSlaveID/GetSlaveID.ino
@@ -34,7 +34,8 @@ seems to be one of few all support identically.
 const int32_t serialBaud = 115200;  // Baud rate for serial monitor
 
 // Define pin number variables
-const int PwrPin = 22;  // The pin sending power to the sensor *AND* RS485 adapter
+const int sensorPwrPin  = 10;  // The pin sending power to the sensor
+const int adapterPwrPin = 22;  // The pin sending power to the sensor *AND* RS485 adapter
 const int DEREPin = -1;   // The pin controlling Recieve Enable and Driver Enable
                           // on the RS485 adapter, if applicable (else, -1)
                           // Setting HIGH enables the driver (arduino) to send text
@@ -199,15 +200,20 @@ void scanSNs(void) {
     if (numFound == 0) Serial.println(F("XXX  --  NO SENSORS FOUND  --  XXX"));
 }
 
-// ---------------------------------------------------------------------------
-// Main setup function
-// ---------------------------------------------------------------------------
+// ==========================================================================
+//  Arduino Setup Function
+// ==========================================================================
 void setup() {
+    if (sensorPwrPin > 0) {
+        pinMode(sensorPwrPin, OUTPUT);
+        digitalWrite(sensorPwrPin, HIGH);
+    }
+    if (adapterPwrPin > 0) {
+        pinMode(adapterPwrPin, OUTPUT);
+        digitalWrite(adapterPwrPin, HIGH);
+    }
 
-    pinMode(PwrPin, OUTPUT);
-    digitalWrite(PwrPin, HIGH);
-
-    if (DEREPin > 0) pinMode(DEREPin, OUTPUT);
+    if (DEREPin > 0) { pinMode(DEREPin, OUTPUT); }
 
     Serial.begin(serialBaud);  // Main serial port for debugging via USB Serial Monitor
     modbusSerial.begin(modbusBaud);

--- a/src/YosemitechModbus.cpp
+++ b/src/YosemitechModbus.cpp
@@ -202,11 +202,14 @@ String yosemitech::getUnits(void) {
 }
 
 
-// This gets the modbus slave ID.  Not supported by many sensors.
-// TODO:  Get list of YosemiTech sensors this works for
+// This gets the modbus slave ID or Sensor Modbus Address.
+// Works for newer sensors, but many older models.
+// TODO: Get list of YosemiTech sensors this works for
+// Works for: new Y4000
 // The slaveID is in register 0x3000 (12288)
 byte yosemitech::getSlaveID(void) {
     byte command[8] = {0xFF, 0x03, 0x30, 0x00, 0x00, 0x01, 0x9E, 0xD4};
+            //  address, ReadHolding, startRegister, numRegisters,  CRC
     modbus.sendCommand(command, 8);
     // int respSize = modbus.sendCommand(command, 8);
     // if (respSize == 7) return modbus.responseBuffer[3];
@@ -215,7 +218,7 @@ byte yosemitech::getSlaveID(void) {
 }
 
 
-// This sets a new modbus slave ID
+// This sets a new modbus slave ID or Sensor Modbus Address.
 // The slaveID is in register 0x3000 (12288)
 bool yosemitech::setSlaveID(byte newSlaveID) {
     byte dataToSend[2] = {newSlaveID, 0x00};
@@ -300,7 +303,7 @@ bool yosemitech::getVersion(float& hardwareVersion, float& softwareVersion) {
 }
 
 
-// This tells the optical sensors to begin taking measurements
+// This tells the sensors to begin taking measurements
 // Note: this doesn't appear to be necessary for the Y4000 sonde
 bool yosemitech::startMeasurement(void) {
     switch (_model) {

--- a/src/YosemitechModbus.h
+++ b/src/YosemitechModbus.h
@@ -18,45 +18,38 @@
  * @brief The various Yosemitech sensors.
  */
 typedef enum yosemitechModel {
-    Y502 = 0,  ///< [Online Optical Dissolved Oxygen
+    Y502 = 0,  ///< [Optical Dissolved Oxygen (discontinued)
                ///< Sensor](http://en.yosemitech.com/aspcms/product/2020-5-8/72.html)
-    Y504,      ///< [Optical Dissolved Oxygen
-               ///< Sensor](http://en.yosemitech.com/aspcms/product/2021-3-1/161.html)
-
-    // Y505,  ///< [Aquaculture Optical Dissolved Oxygen
-    // (ODO)](http://en.yosemitech.com/aspcms/product/2020-5-8/79.html)
-
+    Y504,      ///< [Optical Dissolved Oxygen (ODO)
+               ///< Sensor](https://e.yosemitech.com/DO/Y504-A.html)
+    // Y505,  ///< [ Optical Dissolved Oxygen (ODO) for 
+    //        ///< Aquaculture](https://e.yosemitech.com/DO/Y505-A.html)
     Y510,  ///< [Turbidity
-           ///< Sensor](http://en.yosemitech.com/aspcms/product/2020-5-8/76.html)
-    Y511,  ///<  [Turbidity Sensor with
-           ///<  wiper](http://en.yosemitech.com/aspcms/product/2020-5-8/76.html)
-    Y513,  ///<  [Blue Green Algae sensor with
-           ///<  Wiper](http://en.yosemitech.com/aspcms/product/2020-5-8/82.html)
-    Y514,  ///<  [Chlorophyll Sensor with
-           ///<  Wiper](http://en.yosemitech.com/aspcms/product/2020-4-23/39.html)
+           ///< Sensor](https://e.yosemitech.com/TUR/Y510-B.html)
+    Y511,  ///< [Turbidity Sensor with
+           ///<  wiper](https://e.yosemitech.com/TUR/Y511-A.html)
+    Y513,  ///< [Blue Green Algae (BGA) sensor with
+           ///<  Wiper](https://e.yosemitech.com/CHL/Y513-A.html)
+    Y514,  ///< [Chlorophyll Sensor with
+           ///<  Wiper](https://e.yosemitech.com/CHL/Y514-A.html)
     Y516,  ///< [Oil in water (Crude
            ///< Oil)](http://en.yosemitech.com/aspcms/product/2020-5-8/69.html)
-
     // Y517,    ///< [Oil in water (Refined
     // Oil)](http://en.yosemitech.com/aspcms/product/2020-5-8/69.html)
-
-    Y520,  ///<  [4-Electrode Conductivity
+    Y520,  ///<  [4-Electrode Conductivity (discontinued)
            ///<  Sensor](http://en.yosemitech.com/aspcms/product/2020-4-23/58.html)
-
-    // Y521,    ///<  [4-Electrode Conductivity Sensor(metal
-    // housing)](http://en.yosemitech.com/aspcms/product/2020-4-23/58.html)
-
-    Y532,   ///<  [pH](http://en.yosemitech.com/aspcms/product/2020-6-15/154.html)
-    Y533,   ///<  [ORP](http://en.yosemitech.com/aspcms/product/2020-5-8/91.html)
-    Y550,   ///<  [UV254/COD Sensor, old version no longer
-            ///<  sold](http://en.yosemitech.com/aspcms/product/2020-5-8/94.html)
+    Y521,   ///< [4-Electrode Conductivity Sensor (metal
+            ///< housing)](https://e.yosemitech.com/CT/Y521-A.html)
+    Y532,   ///<  [pH Sensor](https://e.yosemitech.com/pH/Y532-A.html)
+    Y533,   ///<  [ORP Sensor](https://e.yosemitech.com/pH/Y533-A.html)
+    Y550,   ///<  [UV254/COD Sensor (
+            ///<  discontinued)](http://en.yosemitech.com/aspcms/product/2020-5-8/94.html)
     Y551,   ///<  [UV254/COD
-            ///<  Sensor](http://en.yosemitech.com/aspcms/product/2020-5-8/94.html)
-    Y560,   ///<  [NH4 Probe](http://en.yosemitech.com/aspcms/product/2020-4-23/61.html)
-    Y700,   ///<  Water Pressure/Depth Sensor Prototype developed for Clean Water
-            ///<  Services
+            ///<  Sensor](https://e.yosemitech.com/COD-16/Y551-B.html)
+    Y560,   ///<  [Ammonium ISE Sensor](https://e.yosemitech.com/NH4-N-19/Y560-A.html)
+    Y700,   ///<  [Depth Sensor](https://e.yosemitech.com/WLT/68.html)
     Y4000,  ///<  [Multiparameter
-            ///<  Sonde](http://en.yosemitech.com/aspcms/product/2020-5-8/95.html)
+            ///<  Sonde](https://e.yosemitech.com/MULTI/Y4000.html)
     UNKNOWN  ///<  Use if the sensor model is unknown. Doing this is generally a bad
              ///<  idea, but it can be helpful for doing things like getting the serial
              ///<  number of an unknown model.


### PR DESCRIPTION
Added:
- Support for the Y513 Blue Green Algae (BGA) sensor with wiper (773a3a0781a16b7ba6e9f49fadc73cedddce0fbc)
- Added explicit support for the Y521 Conductivity sensor, given that the Y520 has been discontinued.

Fixed:
- The `getValue.ino` example wouldn't work with AltSoftSerial (see d4204ebd1212608aaf05a7a65b763e432c59fe37 and https://github.com/EnviroDIY/SensorModbusMaster/commit/f1daa2fdd22c7ec991fc2ff50330aa41e4a7a53e)
- Fixed broken links to YosemiTech product pages

Improved:
- updated Y504 to first try to get thridvalue for DOmgL before calculating it. 
- The `getValue.ino` example has better formatted outputs.
- The `getSlaveID()` command now works better with broadcast address 0xFF.
  - NOTE that old YosemiTech sensors (before 2020??) don't have a functioning broadcast address
- Successfully tested on new models of Y504, Y511, Y513. 

@SRGDamia1, it would be great to get this released sooner than later, but it's not fully necessary until I add BGA to Modular Sensors.